### PR TITLE
Add new ping script

### DIFF
--- a/ping.sh
+++ b/ping.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+while ((1)); do
+	echo "ping" > /dev/serial/by-id/usb-MicroPython_Board_in_FS_mode_60fdf513bf90cb73-if00
+	sleep 0.5
+done


### PR DESCRIPTION
This continuously pings the Pico, allowing for easy CLI testing (echoing to /dev won't stop after 1 second)